### PR TITLE
Replace dashes with underscore in endpoint name

### DIFF
--- a/swagger_py_codegen/flask.py
+++ b/swagger_py_codegen/flask.py
@@ -96,7 +96,7 @@ def _swagger_to_flask_url(url, swagger_path_node):
 
 
 def _path_to_endpoint(swagger_path):
-    return swagger_path.strip('/').replace('/', '_').translate(None, '{}')
+    return swagger_path.strip('/').replace('/', '_').replace('-', '_').translate(None, '{}')
 
 
 def _path_to_resource_name(swagger_path):
@@ -224,4 +224,3 @@ class FlaskGenerator(CodeGenerator):
 
         if self.with_ui:
             yield UIIndex(dict(spec_path='/static/%s/swagger.json' % self.swagger.module_name))
-

--- a/tests/test_flask.py
+++ b/tests/test_flask.py
@@ -89,6 +89,9 @@ def test_path_to_endpoint():
     }, {
         'path': '/users/{id}/profile',
         'expect': 'users_id_profile'
+    }, {
+        'path': '/users/{id}/hat-size',
+        'expect': 'users_id_hat_size'
     }]
     for case in cases:
         assert _path_to_endpoint(case['path']) == case['expect']


### PR DESCRIPTION
More unblowuppable

Better put: we have APIs with dashes in the resource name. Can't have dashes in package names so this fixes that.