### PR TITLE
Dont modify schema

### DIFF
--- a/swagger_py_codegen/jsonschema.py
+++ b/swagger_py_codegen/jsonschema.py
@@ -182,11 +182,12 @@ def normalize(schema, data, required_defaults=None):
                 result[key] = _normalize(_schema, value)
             elif 'default' in _schema:
                 result[key] = _schema['default']
-            elif key in schema.get('required', []) and type_ in required_defaults:
-                result[key] = required_defaults[type_]
-            else:
-                errors.append(dict(name='property_missing',
-                                   message='`%s` is required' % key))
+            elif key in schema.get('required', []):
+                if type_ in required_defaults:
+                    result[key] = required_defaults[type_]
+                else:
+                    errors.append(dict(name='property_missing',
+                                       message='`%s` is required' % key))
 
         for _schema in schema.get('allOf', []):
             rs_component = _normalize(_schema, data)

--- a/swagger_py_codegen/jsonschema.py
+++ b/swagger_py_codegen/jsonschema.py
@@ -158,10 +158,6 @@ def normalize(schema, data, required_defaults=None):
         for key, _schema in schema.get('properties', {}).iteritems():
             # set default
             type_ = _schema.get('type', 'object')
-            if ('default' not in _schema
-                    and key in schema.get('required', [])
-                    and type_ in required_defaults):
-                _schema['default'] = required_defaults[type_]
 
             # get value
             value = data.get(key)
@@ -169,7 +165,9 @@ def normalize(schema, data, required_defaults=None):
                 result[key] = _normalize(_schema, value)
             elif 'default' in _schema:
                 result[key] = _schema['default']
-            elif key in schema.get('required', []):
+            elif key in schema.get('required', []) and type_ in required_defaults:
+                result[key] = required_defaults[type_]
+            else:
                 errors.append(dict(name='property_missing',
                                    message='`%s` is required' % key))
 

--- a/swagger_py_codegen/jsonschema.py
+++ b/swagger_py_codegen/jsonschema.py
@@ -106,7 +106,7 @@ class SchemaGenerator(CodeGenerator):
         yield Schema(build_data(self.swagger))
 
 
-def merge_default(schema, value):
+def merge_default(schema, value, get_first=True):
     # TODO: more types support
     type_defaults = {
         'integer': 9573,
@@ -116,7 +116,10 @@ def merge_default(schema, value):
         'boolean': False
     }
 
-    return normalize(schema, value, type_defaults)[0]
+    results = normalize(schema, value, type_defaults)
+    if get_first:
+        return results[0]
+    return results
 
 
 def build_default(schema):

--- a/swagger_py_codegen/templates/flask/validators.tpl
+++ b/swagger_py_codegen/templates/flask/validators.tpl
@@ -122,10 +122,10 @@ def response_filter(view):
             # return resp, status, headers
             abort(500, message='`%d` is not a defined status code.' % status)
 
-        resp, errors = merge_default(schemas['schema'], resp, get_first=False)
+        resp, errors = normalize(schemas['schema'], resp)
         if schemas['headers']:
-            headers, header_errors = merge_default(
-                {'properties': schemas['headers']}, headers, get_first=False)
+            headers, header_errors = normalize(
+                {'properties': schemas['headers']}, headers)
             errors.extend(header_errors)
         if errors:
             abort(500, message='Expectation Failed', errors=errors)

--- a/swagger_py_codegen/templates/flask/validators.tpl
+++ b/swagger_py_codegen/templates/flask/validators.tpl
@@ -63,7 +63,7 @@ class FlaskValidatorAdaptor(object):
     def validate(self, value):
         value = self.type_convert(value)
         errors = list(e.message for e in self.validator.iter_errors(value))
-        return merge_default(self.validator.schema, value), errors
+        return normalize(self.validator.schema, value)[0], errors
 
 
 def request_validate(view):
@@ -122,10 +122,10 @@ def response_filter(view):
             # return resp, status, headers
             abort(500, message='`%d` is not a defined status code.' % status)
 
-        resp, errors = normalize(schemas['schema'], resp)
+        resp, errors = merge_default(schemas['schema'], resp, get_first=False)
         if schemas['headers']:
-            headers, header_errors = normalize(
-                {'properties': schemas['headers']}, headers)
+            headers, header_errors = merge_default(
+                {'properties': schemas['headers']}, headers, get_first=False)
             errors.extend(header_errors)
         if errors:
             abort(500, message='Expectation Failed', errors=errors)


### PR DESCRIPTION
```
definitions:
    id:
        type: integer
        format: int32
    A:
        required:
            - id
        properties:
            id:
                $ref: '#/definitions/id'
    B:
        properties:
            id:
                $ref: '#/definitions/id'
```
如上定义，使用A之后，再使用B，B的id就会加上默认值，不应该修改schema，它们使用的是同一个对象

请求的时候不加默认值，响应的时候加默认值