### PR TITLE
Include undefined optional schema properties as None in dto dictionary

### DIFF
--- a/swagger_py_codegen/jsonschema.py
+++ b/swagger_py_codegen/jsonschema.py
@@ -188,6 +188,8 @@ def normalize(schema, data, required_defaults=None):
                 else:
                     errors.append(dict(name='property_missing',
                                        message='`%s` is required' % key))
+            else:
+                result[key] = None
 
         for _schema in schema.get('allOf', []):
             rs_component = _normalize(_schema, data)

--- a/tests/test_jsonschema.py
+++ b/tests/test_jsonschema.py
@@ -290,7 +290,7 @@ def test_merge_default_01():
         }
     }
     result = merge_default(schema, default)
-    assert 'roles' not in result.keys()
+    assert result['roles'] is None
 
 
 def test_merge_default_02():
@@ -511,7 +511,7 @@ def test_normalize_03():
     result, errors = normalize(schema, default)
     assert errors == []
     assert result['name'] == 'bob'
-    assert 'address' not in result.keys()
+    assert result['address'] is None
 
     default = {
         'id': 123,


### PR DESCRIPTION
Previously optional properties were not set on the dto dictionary if not
given in the request. This leads to dictionaries with varying keys of
the same type. Since these dictionaries represent transfer objects,
their varying keys are analogue to varying attributes of transfer
objects.

Objects have a set of attributes, that are predefined. We may construct
objects with some or all attributes set to None, if these attributes
have no value (yet), but they should always be present.

The same principle should be applied to these dto dicitionaries.