### PR TITLE
Handle errors on converting invalid integer/float values

### DIFF
--- a/swagger_py_codegen/templates/flask/validators.tpl
+++ b/swagger_py_codegen/templates/flask/validators.tpl
@@ -31,6 +31,12 @@ class FlaskValidatorAdaptor(object):
     def __init__(self, schema):
         self.validator = Draft4Validator(schema)
 
+    def validate_number(self, type_, value):
+        try:
+            return type_(value)
+        except ValueError:
+            return value
+
     def type_convert(self, obj):
         if obj is None:
             return None
@@ -41,10 +47,10 @@ class FlaskValidatorAdaptor(object):
         result = dict()
 
         convert_funs = {
-            'integer': lambda v: int(v[0]),
+            'integer': lambda v: self.validate_number(int, v[0]),
             'boolean': lambda v: v[0].lower() not in ['n', 'no', 'false', '', '0'],
             'null': lambda v: None,
-            'number': lambda v: float(v[0]),
+            'number': lambda v: self.validate_number(float, v[0]),
             'string': lambda v: v[0]
         }
 


### PR DESCRIPTION
When trying to convert integer/float values and the passed
value is invalid (like a string containing non-digit characters),
handle the resulting ValueError and use the original value
which will cause a proper validation error later on.

Fixes #83.

I'm not too familiar with the code, especially not with `jsonschema`.
Even if this approach is not the correct one, #83 should be fixed anyway I think.