### PR TITLE
Fixes validate none

### DIFF
--- a/swagger_py_codegen/templates/flask/validators.tpl
+++ b/swagger_py_codegen/templates/flask/validators.tpl
@@ -91,6 +91,8 @@ def request_validate(view):
         locations = validators.get((endpoint, method), {})
         for location, schema in six.iteritems(locations):
             value = getattr(request, location, MultiDict())
+            if value is None:
+                value = MultiDict()
             validator = FlaskValidatorAdaptor(schema)
             result, errors = validator.validate(value)
             if errors:


### PR DESCRIPTION
request.json: If the mimetype is application/json this will contain the parsed JSON data. Otherwise this will be None.
If required is defined and value is None, validation can be passed