### PR TITLE
accelerate: replace dpath.get with dict.get

### DIFF
--- a/swagger_py_codegen/parser.py
+++ b/swagger_py_codegen/parser.py
@@ -91,7 +91,10 @@ class Swagger(object):
     def get(self, path):
         key = ''.join(path)
         if key not in self._get_cached:
-            self._get_cached[key] = dpath.util.get(self.data, list(path))
+            value = self.data
+            for p in path:
+                value = value[p]
+            self._get_cached[key] = value
         return self._get_cached[key]
 
     def set(self, path, data):


### PR DESCRIPTION
dpath.util.get 太慢了

```
In [1]: import dpath
In [2]: d = {i: {i: i} for i in range(100000)}
In [3]: time dpath.util.get(d, [555, 555])
CPU times: user 1.76 s, sys: 22.2 ms, total: 1.78 s
Wall time: 1.78 s
Out[3]: 555
In [4]: time d.get(555).get(555)
CPU times: user 5 µs, sys: 7 µs, total: 12 µs
Wall time: 26.9 µs
Out[4]: 555
```

两千行的yaml文档需要30s，改成从dict取才3s，7000+的文档分别是150s、18s，18s中大部分时间都被 dpath.util.search 吃了，可以考虑替换 dpath.util.search