### PR TITLE
Fix ref resolved

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,6 @@ Command Options:
 	-t, --template-dir              Path of your custom templates directory.
 	--spec, --specification         Generate online specification json response.
 	--ui                            Generate swagger ui.
-	-j, --jobs INTEGER              Parallel jobs for processing.
 	-tlp, --templates               gen flask/tornado/falcon templates, default flask.
 	--version                       Show current version.
 	--help                          Show this message and exit.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 six
+json-spec
 click
 jinja2
 dpath

--- a/swagger_py_codegen/command.py
+++ b/swagger_py_codegen/command.py
@@ -95,7 +95,7 @@ def generate(destination, swagger_doc, force=False, package=None,
     pool = Pool(processes=int(jobs))
     package = package or destination.replace('-', '_')
     data = spec_load(swagger_doc)
-    swagger = Swagger(data, pool)
+    swagger = Swagger(data)
     if templates == 'tornado':
         generator = TornadoGenerator(swagger)
     elif templates == 'falcon':

--- a/swagger_py_codegen/command.py
+++ b/swagger_py_codegen/command.py
@@ -4,7 +4,6 @@ try:
     import simplejson as json
 except ImportError:
     import json
-from multiprocessing import Pool
 from os import makedirs
 from os.path import join, exists, dirname
 
@@ -82,17 +81,15 @@ def print_version(ctx, param, value):
 @click.option('--ui',
               default=False, is_flag=True,
               help='Generate swagger ui.')
-@click.option('-j', '--jobs',
-              default=4, help='Parallel jobs for processing.')
 @click.option('-tlp', '--templates',
-              default='flask', help='gen flask/tornado/falcon/sanic templates, default flask.')
+              default='flask',
+              help='gen flask/tornado/falcon/sanic templates, default flask.')
 @click.option('--version', is_flag=True, callback=print_version,
               expose_value=False, is_eager=True,
               help='Show current version.')
 def generate(destination, swagger_doc, force=False, package=None,
              template_dir=None, templates='flask',
-             specification=False, ui=False, jobs=4):
-    pool = Pool(processes=int(jobs))
+             specification=False, ui=False):
     package = package or destination.replace('-', '_')
     data = spec_load(swagger_doc)
     swagger = Swagger(data)

--- a/swagger_py_codegen/jsonschema.py
+++ b/swagger_py_codegen/jsonschema.py
@@ -1,10 +1,11 @@
 from __future__ import absolute_import
+
+import six
 from collections import OrderedDict
 from inspect import getsource
 
 from .base import Code, CodeGenerator
 from .parser import schema_var_name
-import six
 
 
 class Schema(Code):
@@ -129,9 +130,6 @@ def build_default(schema):
 
 
 def normalize(schema, data, required_defaults=None):
-
-    import six
-
     if required_defaults is None:
         required_defaults = {}
     errors = []

--- a/swagger_py_codegen/parser.py
+++ b/swagger_py_codegen/parser.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import
 
-import sys
 import copy
 import six
 from six.moves import map
@@ -24,28 +23,22 @@ class RefNode(dict):
         return schema_var_name(self.ref)
 
 
-class SwaggerSpecError(Exception):
-    pass
-
-
 class Swagger(object):
 
     separator = '\0'
 
-    def __init__(self, data, pool=None):
+    def __init__(self, data):
         self.data = data
         self.origin_data = copy.deepcopy(data)
         self._definitions = []
         self._resolve_definitions()
         self._get_cached = {}
-        if pool:
-            process_references(self, pool)
-        else:
-            self._process_ref()
+
+        self._process_ref()
 
     def _process_ref(self):
         """
-        resolve all references util no reference
+        resolve all references util no reference exists
         """
         while 1:
             li = list(self.search(['**', '$ref']))
@@ -100,11 +93,6 @@ class Swagger(object):
                 self.data, list(path), True, self.separator):
             yield tuple(p.split(self.separator)), d
 
-    def pickle_search(self, path):
-        for p, d in dpath.util.search(self.data, list(path), True,
-                                      self.separator):
-            yield (self, tuple(p.split(self.separator)), d)
-
     def get(self, path):
         key = ''.join(path)
         if key not in self._get_cached:
@@ -115,22 +103,7 @@ class Swagger(object):
         return self._get_cached[key]
 
     def set(self, path, data):
-        # dpath.util.set(self.data, list(path), data)
-        next_ref = self.data
-        for pn in path[:-1]:
-            if isinstance(next_ref, list):
-                next_ref = next_ref[int(pn)]
-            elif isinstance(next_ref, dict):
-                if pn in next_ref:
-                    next_ref = next_ref[pn]
-                elif int(pn) in next_ref:
-                    next_ref = next_ref[int(pn)]
-        if isinstance(next_ref, dict):
-            idx = path[-1]
-            next_ref[idx] = data
-        elif isinstance(next_ref, list):
-            idx = int(path[-1])
-            next_ref[idx] = data
+        _set(self.data, path, data)
 
     @property
     def definitions(self):
@@ -151,44 +124,32 @@ class Swagger(object):
         return self.data.get('basePath', '/v1')
 
 
-def process_input_func(data_to_process):
-    (swagger, path, ref) = data_to_process
-    sys.stdout.write('.')
-    sys.stdout.flush()
-    ref = ref.lstrip('#/').split('/')
-    ref = tuple(ref)
-    try:
-        data = swagger.get(ref)
-    except KeyError:
-        raise SwaggerSpecError('%s %s not defined' % ref)
-    # data = resolve(swagger.data, ref)
-    path = path[:-1]
-    return (path, RefNode(data, ref))
-
-
-def process_references(swagger, pool):
+def _set(obj, path, value):
     """
-    Processed references in swagger data
-    :param swagger:
-    :return:
+    set value for path in the given obj only if path exists.
+    if not, IndexError or KeyError will be raised.
+    params:
+        obj - dict or list object
+        path - list object represents keys in object
+        value - value to be set
     """
-    data_set = pool.map(process_input_func,
-                        swagger.pickle_search(['**', '$ref']))
-    for path, node in data_set:
-        sys.stdout.write('.')
-        sys.stdout.flush()
-        next_ref = swagger.data
-        for pn in path[:-1]:
-            if isinstance(next_ref, list):
-                next_ref = next_ref[int(pn)]
-            elif isinstance(next_ref, dict):
-                if pn in next_ref:
-                    next_ref = next_ref[pn]
-                elif int(pn) in next_ref:
-                    next_ref = next_ref[int(pn)]
-        if isinstance(next_ref, dict):
-            idx = path[-1]
-            next_ref[idx] = node
-        elif isinstance(next_ref, list):
-            idx = int(path[-1])
-            next_ref[idx] = node
+    target = obj
+    for elem in path[:-1]:
+        if isinstance(target, list):
+            target = target[int(elem)]
+        elif isinstance(target, dict):
+            if elem not in target:
+                # special handler out of int status_code
+                # definition in swagger spec
+                elem = int(elem)
+            target = target[elem]
+        else:
+            raise TypeError('try to extract `%s` from target %s'
+                            % (elem, target))
+    idx = path[-1]
+    if isinstance(target, dict):
+        target[idx] = value
+    elif isinstance(target, list):
+        target[int(idx)] = value
+    else:
+        raise TypeError('try to set `%s` for target %s' % (idx, target))

--- a/swagger_py_codegen/parser.py
+++ b/swagger_py_codegen/parser.py
@@ -48,7 +48,7 @@ class Swagger(object):
         resolve all references util no reference
         """
         while 1:
-            li = self.search(['**', '$ref'])
+            li = list(self.search(['**', '$ref']))
             if not li:
                 break
             for path, ref in li:
@@ -81,7 +81,10 @@ class Swagger(object):
 
         definition_refs = get_definition_refs()
         while definition_refs:
-            ready = {definition for definition, refs in six.iteritems(definition_refs) if not refs}
+            ready = {
+                definition for definition, refs
+                in six.iteritems(definition_refs) if not refs
+            }
             if not ready:
                 msg = '$ref circular references found!\n'
                 raise ValueError(msg)
@@ -93,10 +96,9 @@ class Swagger(object):
             self._definitions += ready
 
     def search(self, path):
-        li = []
-        for p, d in dpath.util.search(self.data, list(path), True, self.separator):
-            li.append((tuple(p.split(self.separator)), d))
-        return li
+        for p, d in dpath.util.search(
+                self.data, list(path), True, self.separator):
+            yield tuple(p.split(self.separator)), d
 
     def pickle_search(self, path):
         for p, d in dpath.util.search(self.data, list(path), True,

--- a/swagger_py_codegen/parser.py
+++ b/swagger_py_codegen/parser.py
@@ -39,7 +39,6 @@ class Swagger(object):
         self._resolve_definitions()
         self._get_cached = {}
         if pool:
-            pool.map()
             process_references(self, pool)
         else:
             self._process_ref()
@@ -114,7 +113,22 @@ class Swagger(object):
         return self._get_cached[key]
 
     def set(self, path, data):
-        dpath.util.set(self.data, list(path), data)
+        # dpath.util.set(self.data, list(path), data)
+        next_ref = self.data
+        for pn in path[:-1]:
+            if isinstance(next_ref, list):
+                next_ref = next_ref[int(pn)]
+            elif isinstance(next_ref, dict):
+                if pn in next_ref:
+                    next_ref = next_ref[pn]
+                elif int(pn) in next_ref:
+                    next_ref = next_ref[int(pn)]
+        if isinstance(next_ref, dict):
+            idx = path[-1]
+            next_ref[idx] = data
+        elif isinstance(next_ref, list):
+            idx = int(path[-1])
+            next_ref[idx] = data
 
     @property
     def definitions(self):

--- a/swagger_py_codegen/templates/jsonschema/schemas.tpl
+++ b/swagger_py_codegen/templates/jsonschema/schemas.tpl
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 
+import six
+
 # TODO: datetime support
 
 {% include '_do_not_change.tpl' %}
@@ -49,4 +51,3 @@ security = Security()
 {{ merge_default }}
 
 {{ normalize }}
-

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -204,7 +204,7 @@ def test_swagger_ref_node():
         }
     }
     swagger = Swagger(data)
-    p = swagger.get(['definitions', 'Order', 'properties', 'products', 'items'])
+    p = swagger.get(
+        ['definitions', 'Order', 'properties', 'products', 'items'])
     assert p['properties']['name']['type'] == 'string'
-    # assert str(p) == 'DefinitionsProduct'
-    # assert repr(p) == 'DefinitionsProduct'
+    assert p['properties']['seller']['properties']['age']['type'] == 'number'

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -164,7 +164,7 @@ def test_swagger_ref_count_04():
     }
     with pytest.raises(ValueError) as excinfo:
         Swagger(data)
-        assert excinfo.type == exceptions.ValueError
+        assert excinfo.type == ValueError
 
 
 def test_swagger_ref_node():
@@ -206,5 +206,5 @@ def test_swagger_ref_node():
     swagger = Swagger(data)
     p = swagger.get(['definitions', 'Order', 'properties', 'products', 'items'])
     assert p['properties']['name']['type'] == 'string'
-    assert str(p) == 'DefinitionsProduct'
-    assert repr(p) == 'DefinitionsProduct'
+    # assert str(p) == 'DefinitionsProduct'
+    # assert repr(p) == 'DefinitionsProduct'


### PR DESCRIPTION
1. 之前的swagger parser解析不完全，没有考虑到引用的嵌套情况。从而导致生成的`validators`中可能存在`$ref`从而无法进行校验，如下：
```
('pets', 'POST'): {'json': {'$ref': '#/definitions/Pets'}, 'args': {'required': [], 'properties': {'limit': {'required': False, 'format': 'int32'}}}}
```
2. 代码生成速度的瓶颈在于swagger parser的set方法使用了`dpath.util.set`。master在使用`multiprocessing`的情况下，同时又使用了自己实现的set方法[https://github.com/guokr/swagger-py-codegen/blob/master/swagger_py_codegen/parser.py#L145](https://github.com/guokr/swagger-py-codegen/blob/master/swagger_py_codegen/parser.py#L145)。所以实际上并非`multiprocessing`提高了代码生成速度。