### PR TITLE
tornado, fix post json error using request body

### DIFF
--- a/swagger_py_codegen/templates/tornado/validators.tpl
+++ b/swagger_py_codegen/templates/tornado/validators.tpl
@@ -40,12 +40,15 @@ class ValidatorAdaptor(object):
             obj = MultiDict(six.iteritems(obj))
         result = dict()
 
+        def convert_string_if_bytes(value):
+            return bytes.decode(value) if isinstance(value, bytes) else value
+
         convert_funs = {
             'integer': lambda v: self.validate_number(int, v[0]),
-            'boolean': lambda v: bytes.decode(v[0]).lower() not in ['n', 'no', 'false', '', '0'],
+            'boolean': lambda v: convert_string_if_bytes(v[0]).lower() not in ['n', 'no', 'false', '', '0'],
             'null': lambda v: None,
             'number': lambda v: self.validate_number(float, v[0]),
-            'string': lambda v: bytes.decode(v[0]) if isinstance(v[0], bytes) else v[0]
+            'string': lambda v: convert_string_if_bytes(v[0])
         }
 
         def convert_array(type_, v):

--- a/swagger_py_codegen/templates/tornado/validators.tpl
+++ b/swagger_py_codegen/templates/tornado/validators.tpl
@@ -26,12 +26,6 @@ class ValidatorAdaptor(object):
             return value
 
     @staticmethod
-    def convert_to_string_if_bytes(value):
-        if isinstance(value, bytes):
-            return bytes.decode(value)
-        return value
-
-    @staticmethod
     def get_ref_obj(ref):
         fields = ref.split('/')
         obj = definitions
@@ -61,7 +55,7 @@ class ValidatorAdaptor(object):
             'boolean': lambda v: v[0].lower() not in ['n', 'no', 'false', '', '0'],
             'null': lambda v: None,
             'number': lambda v: self.validate_number(float, v[0]),
-            'string': lambda v: self.convert_to_string_if_bytes(v[0])
+            'string': lambda v: bytes.decode(v[0]) if isinstance(v[0], bytes) else v[0]
         }
 
         def convert_array(type_, v):

--- a/swagger_py_codegen/templates/tornado/validators.tpl
+++ b/swagger_py_codegen/templates/tornado/validators.tpl
@@ -123,8 +123,8 @@ def response_filter(obj):
             method = request.method
             if method == 'HEAD':
                 method = 'GET'
-            headers = None
-            status = None
+            headers = {}
+            status = 200
             if isinstance(resp, tuple):
                 resp, status, headers = unpack(resp)
             filter = filters.get((endpoint, method), None)

--- a/swagger_py_codegen/templates/tornado/validators.tpl
+++ b/swagger_py_codegen/templates/tornado/validators.tpl
@@ -42,7 +42,7 @@ class ValidatorAdaptor(object):
 
         convert_funs = {
             'integer': lambda v: self.validate_number(int, v[0]),
-            'boolean': lambda v: v[0].lower() not in ['n', 'no', 'false', '', '0'],
+            'boolean': lambda v: bytes.decode(v[0]).lower() not in ['n', 'no', 'false', '', '0'],
             'null': lambda v: None,
             'number': lambda v: self.validate_number(float, v[0]),
             'string': lambda v: bytes.decode(v[0]) if isinstance(v[0], bytes) else v[0]

--- a/swagger_py_codegen/templates/tornado/validators.tpl
+++ b/swagger_py_codegen/templates/tornado/validators.tpl
@@ -11,7 +11,7 @@ import six
 from functools import wraps
 from jsonschema import Draft4Validator
 
-from .schemas import definitions, validators, scopes, resolver, normalize, filters
+from .schemas import validators, scopes, resolver, normalize, filters
 
 
 class ValidatorAdaptor(object):

--- a/swagger_py_codegen/templates/tornado/validators.tpl
+++ b/swagger_py_codegen/templates/tornado/validators.tpl
@@ -29,7 +29,7 @@ class ValidatorAdaptor(object):
         if obj is None or not obj:
             return None
         if six.PY3:
-            if isinstance(obj, str):
+            if isinstance(obj, str) or isinstance(obj, bytes):
                 obj = MultiDict(json.loads(obj))
         else:
             if isinstance(obj, (str, unicode, basestring)):

--- a/swagger_py_codegen/templates/tornado/validators.tpl
+++ b/swagger_py_codegen/templates/tornado/validators.tpl
@@ -26,6 +26,12 @@ class ValidatorAdaptor(object):
             return value
 
     @staticmethod
+    def convert_to_string_if_bytes(value):
+        if isinstance(value, bytes):
+            return bytes.decode(value)
+        return value
+
+    @staticmethod
     def get_ref_obj(ref):
         fields = ref.split('/')
         obj = definitions
@@ -55,7 +61,7 @@ class ValidatorAdaptor(object):
             'boolean': lambda v: v[0].lower() not in ['n', 'no', 'false', '', '0'],
             'null': lambda v: None,
             'number': lambda v: self.validate_number(float, v[0]),
-            'string': lambda v: v[0]
+            'string': lambda v: self.convert_to_string_if_bytes(v[0])
         }
 
         def convert_array(type_, v):

--- a/swagger_py_codegen/templates/tornado/validators.tpl
+++ b/swagger_py_codegen/templates/tornado/validators.tpl
@@ -63,11 +63,11 @@ class ValidatorAdaptor(object):
             return [func([i]) for i in v]
 
         for k, values in obj.lists():
-            obj = self.validator.schema
-            if '$ref' in obj:
-                obj = self.get_ref_obj(obj['$ref'])
+            schema = self.validator.schema
+            if '$ref' in schema:
+                schema = self.get_ref_obj(schema['$ref'])
 
-            prop = obj['properties'].get(k, {})
+            prop = schema['properties'].get(k, {})
             type_ = prop.get('type')
             fun = convert_funs.get(type_, lambda v: v[0])
             if type_ == 'array':

--- a/swagger_py_codegen/templates/tornado/validators.tpl
+++ b/swagger_py_codegen/templates/tornado/validators.tpl
@@ -25,16 +25,6 @@ class ValidatorAdaptor(object):
         except ValueError:
             return value
 
-    @staticmethod
-    def get_ref_obj(ref):
-        fields = ref.split('/')
-        obj = definitions
-        for value in fields:
-            if value == '#':
-                continue
-            obj = obj[value]
-        return obj
-
     def type_convert(self, obj):
         if obj is None or not obj:
             return None
@@ -65,7 +55,7 @@ class ValidatorAdaptor(object):
         for k, values in obj.lists():
             schema = self.validator.schema
             if '$ref' in schema:
-                schema = self.get_ref_obj(schema['$ref'])
+                _, schema = resolver.resolve(schema['$ref'])
 
             prop = schema['properties'].get(k, {})
             type_ = prop.get('type')


### PR DESCRIPTION
1. fix post json error using request body:
json data is bytes, not string, cause validation failed.
2. support ref in request body:
```
    post:
      summary: Creates a new user.
      consumes:
        - application/json
      parameters:
        - in: body
          name: user
          description: The user to create.
          schema:
            $ref: '#/definitions/User'     # <----------
```